### PR TITLE
Add Modal HTTP endpoints and website for polyform renderings

### DIFF
--- a/renderings/README.md
+++ b/renderings/README.md
@@ -1,0 +1,225 @@
+# Heesch Polyform Renderings
+
+This directory contains a Modal-based HTTP API for rendering polyforms and a website frontend.
+
+## Directory Structure
+
+```
+renderings/
+├── modal/           # Modal app with HTTP endpoints
+│   ├── app.py       # Main Modal app with endpoints
+│   ├── render.py    # SVG rendering utilities
+│   └── __init__.py
+├── website/         # Frontend website
+│   ├── index.html   # Main HTML page
+│   ├── styles.css   # Styles
+│   └── app.js       # JavaScript app
+└── README.md        # This file
+```
+
+## Modal Endpoints
+
+### GET /render
+
+Get or compute a rendering for a polyform.
+
+**Parameters:**
+- `grid_type`: Single character grid type (O, H, I, o, T, A, D, K, h, B)
+- `coords`: Coordinates as "x1,y1_x2,y2_x3,y3" format
+
+**Response:**
+```json
+{
+    "status": "available" | "computing" | "error",
+    "grid_type": "H",
+    "grid_name": "Polyhex",
+    "coords": "0,0_1,0_2,0",
+    "svg": "<svg>...</svg>"
+}
+```
+
+If status is "computing", the rendering is being computed in the background. Poll again to get the result.
+
+### GET /render_sync
+
+Same as `/render` but blocks until the rendering is ready (synchronous).
+
+### GET /list_polyforms
+
+List available polyforms.
+
+**Parameters:**
+- `grid_type` (optional): Filter by grid type
+
+**Response:**
+```json
+{
+    "polyforms": [
+        {
+            "grid_type": "H",
+            "grid_name": "Polyhex",
+            "coords": "0,0_1,0_2,0"
+        }
+    ]
+}
+```
+
+### GET /grid_types
+
+List all supported grid types.
+
+**Response:**
+```json
+{
+    "grid_types": [
+        {"abbrev": "O", "name": "omino", "full_name": "Polyomino"},
+        {"abbrev": "H", "name": "hex", "full_name": "Polyhex"},
+        ...
+    ]
+}
+```
+
+## Grid Types
+
+| Abbrev | Name | Description |
+|--------|------|-------------|
+| O | omino | Polyomino (square grid) |
+| H | hex | Polyhex (hexagonal grid) |
+| I | iamond | Polyiamond (triangular grid) |
+| o | octasquare | Poly-[4.8.8] |
+| T | trihex | Poly-[3.6.3.6] |
+| A | abolo | Polyabolo (right triangles) |
+| D | drafter | Polydrafter (30-60-90 triangles) |
+| K | kite | Polykite |
+| h | halfcairo | Polyhalfcairo |
+| B | bevelhex | Polybevelhex |
+
+## Coordinate Format
+
+Coordinates are specified as underscore-separated pairs:
+
+```
+x1,y1_x2,y2_x3,y3_...
+```
+
+Example: A polyhex with 4 cells:
+```
+0,0_1,0_2,0_2,1
+```
+
+The coordinates are automatically sorted and normalized.
+
+## Deployment
+
+### Prerequisites
+
+1. Install Modal: `pip install modal`
+2. Authenticate: `modal token new`
+
+### Deploy the App
+
+```bash
+cd renderings/modal
+modal deploy app.py
+```
+
+This will output the endpoint URLs.
+
+### Update Website Configuration
+
+After deployment, update the `CONFIG.baseUrl` in `website/app.js` with your Modal username:
+
+```javascript
+const CONFIG = {
+    baseUrl: 'https://YOUR_MODAL_USERNAME--heesch-renderings',
+    // ...
+};
+```
+
+### Serve the Website
+
+You can serve the website locally or deploy to any static hosting:
+
+```bash
+cd renderings/website
+python -m http.server 8000
+```
+
+Then open http://localhost:8000
+
+## Volume Storage
+
+Renderings are stored in a Modal volume (`heesch-renderings-vol`):
+
+```
+/data/
+├── renderings/
+│   ├── H/           # Polyhex renderings
+│   │   └── H_0,0_1,0_2,0.svg
+│   ├── O/           # Polyomino renderings
+│   └── ...
+└── index/
+    ├── H.json       # Index of available polyhex
+    └── ...
+```
+
+## Local Development
+
+Test rendering locally:
+
+```bash
+cd renderings/modal
+python -c "
+from render import render_polyform
+svg = render_polyform('H', [(0,0), (1,0), (2,0), (2,1)])
+print(svg)
+"
+```
+
+## Example Usage
+
+### Using curl
+
+```bash
+# Get a hex polyform rendering
+curl "https://YOUR_MODAL_USERNAME--heesch-renderings-render.modal.run?grid_type=H&coords=0,0_1,0_2,0"
+
+# List available polyforms
+curl "https://YOUR_MODAL_USERNAME--heesch-renderings-list-polyforms.modal.run"
+
+# List grid types
+curl "https://YOUR_MODAL_USERNAME--heesch-renderings-grid-types.modal.run"
+```
+
+### Using Python
+
+```python
+import requests
+
+BASE_URL = "https://YOUR_MODAL_USERNAME--heesch-renderings"
+
+# Get a rendering
+response = requests.get(f"{BASE_URL}-render.modal.run", params={
+    "grid_type": "H",
+    "coords": "0,0_1,0_2,0_2,1"
+})
+data = response.json()
+
+if data["status"] == "available":
+    print(data["svg"])
+elif data["status"] == "computing":
+    print("Computing... try again in a moment")
+```
+
+### Using JavaScript
+
+```javascript
+const response = await fetch(
+    'https://YOUR_MODAL_USERNAME--heesch-renderings-render.modal.run?grid_type=H&coords=0,0_1,0_2,0'
+);
+const data = await response.json();
+
+if (data.status === 'available') {
+    document.getElementById('output').innerHTML = data.svg;
+}
+```

--- a/renderings/modal/__init__.py
+++ b/renderings/modal/__init__.py
@@ -1,0 +1,1 @@
+# Modal app for Heesch polyform renderings

--- a/renderings/modal/app.py
+++ b/renderings/modal/app.py
@@ -1,0 +1,262 @@
+"""
+Modal app with HTTP endpoints for polyform renderings.
+
+Endpoints:
+- GET /render?grid_type=H&coords=0,0_1,0_2,0 - Get or compute rendering
+- GET /list?grid_type=H - List available polyforms for a grid type
+- GET /grid_types - List all supported grid types
+"""
+
+import modal
+import json
+import os
+from typing import Optional
+
+from render import (
+    render_polyform,
+    coords_to_key,
+    parse_coords,
+    coords_to_string,
+    GRID_TYPES,
+    GRID_NAMES,
+)
+
+# Create Modal app
+app = modal.App("heesch-renderings")
+
+# Volume for storing computed renderings
+volume = modal.Volume.from_name("heesch-renderings-vol", create_if_missing=True)
+VOLUME_PATH = "/data"
+
+# Image with dependencies
+image = modal.Image.debian_slim(python_version="3.11")
+
+
+def get_rendering_path(grid_type: str, coords_str: str) -> str:
+    """Get path in volume for a rendering."""
+    key = f"{grid_type}_{coords_str}"
+    return os.path.join(VOLUME_PATH, "renderings", grid_type, f"{key}.svg")
+
+
+def get_index_path(grid_type: str) -> str:
+    """Get path to index file for a grid type."""
+    return os.path.join(VOLUME_PATH, "index", f"{grid_type}.json")
+
+
+@app.function(image=image, volumes={VOLUME_PATH: volume})
+def compute_and_store_rendering(grid_type: str, coords_str: str) -> str:
+    """Compute a rendering and store it in the volume."""
+    from render import render_polyform, parse_coords
+
+    coords = parse_coords(coords_str)
+    svg = render_polyform(grid_type, coords)
+
+    # Ensure directory exists
+    rendering_path = get_rendering_path(grid_type, coords_str)
+    os.makedirs(os.path.dirname(rendering_path), exist_ok=True)
+
+    # Write SVG
+    with open(rendering_path, 'w') as f:
+        f.write(svg)
+
+    # Update index
+    update_index(grid_type, coords_str)
+
+    volume.commit()
+    return svg
+
+
+def update_index(grid_type: str, coords_str: str):
+    """Update the index file for a grid type."""
+    index_path = get_index_path(grid_type)
+    os.makedirs(os.path.dirname(index_path), exist_ok=True)
+
+    # Load existing index or create new
+    if os.path.exists(index_path):
+        with open(index_path, 'r') as f:
+            index = json.load(f)
+    else:
+        index = {"grid_type": grid_type, "polyforms": []}
+
+    # Add new entry if not exists
+    if coords_str not in index["polyforms"]:
+        index["polyforms"].append(coords_str)
+        with open(index_path, 'w') as f:
+            json.dump(index, f)
+
+
+@app.function(image=image, volumes={VOLUME_PATH: volume})
+@modal.web_endpoint(method="GET")
+def render(grid_type: str, coords: str) -> dict:
+    """
+    Get rendering for a polyform.
+
+    Args:
+        grid_type: Single character grid type (O, H, I, etc.)
+        coords: Coordinates as "x1,y1_x2,y2_x3,y3" format
+
+    Returns:
+        JSON with status and svg (if available)
+    """
+    # Validate grid type
+    if grid_type not in GRID_TYPES:
+        return {
+            "status": "error",
+            "message": f"Invalid grid type: {grid_type}. Valid types: {list(GRID_TYPES.keys())}"
+        }
+
+    # Normalize coordinates (sort them)
+    try:
+        parsed = parse_coords(coords)
+        coords_str = coords_to_string(parsed)
+    except (ValueError, IndexError):
+        return {
+            "status": "error",
+            "message": f"Invalid coordinates format: {coords}"
+        }
+
+    # Check if rendering exists in volume
+    rendering_path = get_rendering_path(grid_type, coords_str)
+    volume.reload()
+
+    if os.path.exists(rendering_path):
+        with open(rendering_path, 'r') as f:
+            svg = f.read()
+        return {
+            "status": "available",
+            "grid_type": grid_type,
+            "grid_name": GRID_NAMES.get(grid_type, "Unknown"),
+            "coords": coords_str,
+            "svg": svg
+        }
+
+    # Not available - start computing in background
+    compute_and_store_rendering.spawn(grid_type, coords_str)
+
+    return {
+        "status": "computing",
+        "message": "Rendering is being computed. Please try again shortly.",
+        "grid_type": grid_type,
+        "grid_name": GRID_NAMES.get(grid_type, "Unknown"),
+        "coords": coords_str
+    }
+
+
+@app.function(image=image, volumes={VOLUME_PATH: volume})
+@modal.web_endpoint(method="GET")
+def list_polyforms(grid_type: Optional[str] = None) -> dict:
+    """
+    List available polyforms.
+
+    Args:
+        grid_type: Optional filter by grid type
+
+    Returns:
+        JSON with list of available polyforms
+    """
+    volume.reload()
+
+    result = {"polyforms": []}
+
+    if grid_type:
+        if grid_type not in GRID_TYPES:
+            return {
+                "status": "error",
+                "message": f"Invalid grid type: {grid_type}"
+            }
+        grid_types = [grid_type]
+    else:
+        grid_types = list(GRID_TYPES.keys())
+
+    for gt in grid_types:
+        index_path = get_index_path(gt)
+        if os.path.exists(index_path):
+            with open(index_path, 'r') as f:
+                index = json.load(f)
+            for coords_str in index.get("polyforms", []):
+                result["polyforms"].append({
+                    "grid_type": gt,
+                    "grid_name": GRID_NAMES.get(gt, "Unknown"),
+                    "coords": coords_str
+                })
+
+    return result
+
+
+@app.function(image=image)
+@modal.web_endpoint(method="GET")
+def grid_types() -> dict:
+    """List all supported grid types."""
+    return {
+        "grid_types": [
+            {"abbrev": k, "name": v, "full_name": GRID_NAMES.get(k, v)}
+            for k, v in GRID_TYPES.items()
+        ]
+    }
+
+
+@app.function(image=image, volumes={VOLUME_PATH: volume})
+@modal.web_endpoint(method="GET")
+def render_sync(grid_type: str, coords: str) -> dict:
+    """
+    Get rendering for a polyform, computing synchronously if needed.
+
+    This endpoint blocks until the rendering is ready.
+    Use the async 'render' endpoint for non-blocking behavior.
+
+    Args:
+        grid_type: Single character grid type (O, H, I, etc.)
+        coords: Coordinates as "x1,y1_x2,y2_x3,y3" format
+
+    Returns:
+        JSON with svg
+    """
+    from render import render_polyform, parse_coords
+
+    # Validate grid type
+    if grid_type not in GRID_TYPES:
+        return {
+            "status": "error",
+            "message": f"Invalid grid type: {grid_type}"
+        }
+
+    # Normalize coordinates
+    try:
+        parsed = parse_coords(coords)
+        coords_str = coords_to_string(parsed)
+    except (ValueError, IndexError):
+        return {
+            "status": "error",
+            "message": f"Invalid coordinates format: {coords}"
+        }
+
+    # Check if rendering exists
+    rendering_path = get_rendering_path(grid_type, coords_str)
+    volume.reload()
+
+    if os.path.exists(rendering_path):
+        with open(rendering_path, 'r') as f:
+            svg = f.read()
+    else:
+        # Compute and store
+        svg = compute_and_store_rendering.local(grid_type, coords_str)
+
+    return {
+        "status": "available",
+        "grid_type": grid_type,
+        "grid_name": GRID_NAMES.get(grid_type, "Unknown"),
+        "coords": coords_str,
+        "svg": svg
+    }
+
+
+# Local entry point for testing
+if __name__ == "__main__":
+    # Test rendering locally
+    from render import render_polyform
+
+    # Test hex polyform
+    coords = [(0, 0), (1, 0), (2, 0), (2, 1)]
+    svg = render_polyform('H', coords)
+    print("Test hex rendering:")
+    print(svg[:200] + "...")

--- a/renderings/modal/render.py
+++ b/renderings/modal/render.py
@@ -1,0 +1,323 @@
+"""
+SVG rendering utilities for polyforms.
+Generates SVG representations of polyforms based on grid type and coordinates.
+"""
+
+import math
+from typing import List, Tuple
+
+# Grid type abbreviations (matching C++ common.h)
+GRID_TYPES = {
+    'O': 'omino',      # Polyomino
+    'H': 'hex',        # Polyhex
+    'I': 'iamond',     # Polyiamond
+    'o': 'octasquare', # Poly-[4.8.8]
+    'T': 'trihex',     # Poly-[3.6.3.6]
+    'A': 'abolo',      # Polyabolo
+    'D': 'drafter',    # Polydrafter
+    'K': 'kite',       # Polykite
+    'h': 'halfcairo',  # Polyhalfcairo
+    'B': 'bevelhex',   # Polybevelhex
+}
+
+GRID_NAMES = {
+    'O': 'Polyomino',
+    'H': 'Polyhex',
+    'I': 'Polyiamond',
+    'o': 'Poly-[4.8.8]',
+    'T': 'Poly-[3.6.3.6]',
+    'A': 'Polyabolo',
+    'D': 'Polydrafter',
+    'K': 'Polykite',
+    'h': 'Polyhalfcairo',
+    'B': 'Polybevelhex',
+}
+
+
+def coords_to_key(grid_type: str, coords: List[Tuple[int, int]]) -> str:
+    """Generate a unique key for a polyform based on grid type and coordinates."""
+    sorted_coords = sorted(coords)
+    coord_str = '_'.join(f"{x},{y}" for x, y in sorted_coords)
+    return f"{grid_type}_{coord_str}"
+
+
+def parse_coords(coord_string: str) -> List[Tuple[int, int]]:
+    """Parse a coordinate string like '0,0_1,0_2,0' into list of tuples."""
+    if not coord_string:
+        return []
+    pairs = coord_string.split('_')
+    result = []
+    for pair in pairs:
+        x, y = pair.split(',')
+        result.append((int(x), int(y)))
+    return result
+
+
+def coords_to_string(coords: List[Tuple[int, int]]) -> str:
+    """Convert coordinates to string format."""
+    return '_'.join(f"{x},{y}" for x, y in sorted(coords))
+
+
+class PolyformRenderer:
+    """Base class for rendering polyforms to SVG."""
+
+    def __init__(self, grid_type: str, coords: List[Tuple[int, int]]):
+        self.grid_type = grid_type
+        self.coords = coords
+        self.cell_size = 30
+        self.padding = 20
+        self.fill_color = "#FFD700"  # Gold
+        self.stroke_color = "#000000"
+        self.stroke_width = 2
+
+    def get_bounds(self) -> Tuple[float, float, float, float]:
+        """Get bounding box of all cells. Returns (min_x, min_y, max_x, max_y)."""
+        raise NotImplementedError
+
+    def render_cell(self, x: int, y: int) -> str:
+        """Render a single cell as SVG path."""
+        raise NotImplementedError
+
+    def render(self) -> str:
+        """Render the complete polyform as SVG."""
+        if not self.coords:
+            return self._empty_svg()
+
+        min_x, min_y, max_x, max_y = self.get_bounds()
+        width = max_x - min_x + 2 * self.padding
+        height = max_y - min_y + 2 * self.padding
+
+        svg_parts = [
+            f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" width="{width}" height="{height}">',
+            f'<g transform="translate({self.padding - min_x}, {self.padding - min_y})">'
+        ]
+
+        for x, y in self.coords:
+            svg_parts.append(self.render_cell(x, y))
+
+        svg_parts.append('</g></svg>')
+        return '\n'.join(svg_parts)
+
+    def _empty_svg(self) -> str:
+        return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100"></svg>'
+
+
+class OminoRenderer(PolyformRenderer):
+    """Renderer for polyominoes (square grid)."""
+
+    def get_bounds(self) -> Tuple[float, float, float, float]:
+        if not self.coords:
+            return (0, 0, 100, 100)
+        xs = [x * self.cell_size for x, y in self.coords]
+        ys = [y * self.cell_size for x, y in self.coords]
+        return (min(xs), min(ys), max(xs) + self.cell_size, max(ys) + self.cell_size)
+
+    def render_cell(self, x: int, y: int) -> str:
+        px = x * self.cell_size
+        py = y * self.cell_size
+        return f'<rect x="{px}" y="{py}" width="{self.cell_size}" height="{self.cell_size}" fill="{self.fill_color}" stroke="{self.stroke_color}" stroke-width="{self.stroke_width}"/>'
+
+
+class HexRenderer(PolyformRenderer):
+    """Renderer for polyhexes (hexagonal grid)."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.hex_size = 20  # Radius of hexagon
+
+    def _hex_to_pixel(self, x: int, y: int) -> Tuple[float, float]:
+        """Convert hex coordinates to pixel coordinates."""
+        # Offset coordinates - y axis is at 60 degrees
+        px = self.hex_size * 1.5 * x
+        py = self.hex_size * math.sqrt(3) * (y + x * 0.5)
+        return (px, py)
+
+    def _hex_vertices(self, cx: float, cy: float) -> List[Tuple[float, float]]:
+        """Get vertices of a flat-top hexagon centered at (cx, cy)."""
+        vertices = []
+        for i in range(6):
+            angle = math.pi / 3 * i
+            vx = cx + self.hex_size * math.cos(angle)
+            vy = cy + self.hex_size * math.sin(angle)
+            vertices.append((vx, vy))
+        return vertices
+
+    def get_bounds(self) -> Tuple[float, float, float, float]:
+        if not self.coords:
+            return (0, 0, 100, 100)
+        all_vertices = []
+        for x, y in self.coords:
+            cx, cy = self._hex_to_pixel(x, y)
+            all_vertices.extend(self._hex_vertices(cx, cy))
+        xs = [v[0] for v in all_vertices]
+        ys = [v[1] for v in all_vertices]
+        return (min(xs), min(ys), max(xs), max(ys))
+
+    def render_cell(self, x: int, y: int) -> str:
+        cx, cy = self._hex_to_pixel(x, y)
+        vertices = self._hex_vertices(cx, cy)
+        points = ' '.join(f'{vx},{vy}' for vx, vy in vertices)
+        return f'<polygon points="{points}" fill="{self.fill_color}" stroke="{self.stroke_color}" stroke-width="{self.stroke_width}"/>'
+
+
+class IamondRenderer(PolyformRenderer):
+    """Renderer for polyiamonds (triangular grid)."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.tri_size = 25
+
+    def _is_up_triangle(self, x: int) -> bool:
+        """Determine if triangle points up based on x coordinate."""
+        return (x % 3) == 0
+
+    def _tri_to_pixel(self, x: int, y: int) -> Tuple[float, float]:
+        """Convert iamond coordinates to pixel center."""
+        # Similar to hex but sparser
+        px = self.tri_size * 0.5 * x
+        py = self.tri_size * math.sqrt(3) * 0.5 * y
+        return (px, py)
+
+    def _tri_vertices(self, x: int, y: int) -> List[Tuple[float, float]]:
+        """Get vertices of triangle at (x, y)."""
+        cx, cy = self._tri_to_pixel(x, y)
+        h = self.tri_size * math.sqrt(3) / 2
+
+        if self._is_up_triangle(x):
+            # Up-pointing triangle
+            return [
+                (cx, cy - h * 2/3),
+                (cx - self.tri_size/2, cy + h/3),
+                (cx + self.tri_size/2, cy + h/3),
+            ]
+        else:
+            # Down-pointing triangle
+            return [
+                (cx, cy + h * 2/3),
+                (cx - self.tri_size/2, cy - h/3),
+                (cx + self.tri_size/2, cy - h/3),
+            ]
+
+    def get_bounds(self) -> Tuple[float, float, float, float]:
+        if not self.coords:
+            return (0, 0, 100, 100)
+        all_vertices = []
+        for x, y in self.coords:
+            all_vertices.extend(self._tri_vertices(x, y))
+        xs = [v[0] for v in all_vertices]
+        ys = [v[1] for v in all_vertices]
+        return (min(xs), min(ys), max(xs), max(ys))
+
+    def render_cell(self, x: int, y: int) -> str:
+        vertices = self._tri_vertices(x, y)
+        points = ' '.join(f'{vx},{vy}' for vx, vy in vertices)
+        return f'<polygon points="{points}" fill="{self.fill_color}" stroke="{self.stroke_color}" stroke-width="{self.stroke_width}"/>'
+
+
+class AboloRenderer(PolyformRenderer):
+    """Renderer for polyabolos (right triangles on square grid)."""
+
+    def _tri_vertices(self, x: int, y: int) -> List[Tuple[float, float]]:
+        """Get vertices of right triangle at (x, y)."""
+        px = x * self.cell_size
+        py = y * self.cell_size
+        # Alternating orientation based on position
+        if (x + y) % 2 == 0:
+            return [
+                (px, py),
+                (px + self.cell_size, py),
+                (px, py + self.cell_size),
+            ]
+        else:
+            return [
+                (px + self.cell_size, py),
+                (px + self.cell_size, py + self.cell_size),
+                (px, py + self.cell_size),
+            ]
+
+    def get_bounds(self) -> Tuple[float, float, float, float]:
+        if not self.coords:
+            return (0, 0, 100, 100)
+        all_vertices = []
+        for x, y in self.coords:
+            all_vertices.extend(self._tri_vertices(x, y))
+        xs = [v[0] for v in all_vertices]
+        ys = [v[1] for v in all_vertices]
+        return (min(xs), min(ys), max(xs), max(ys))
+
+    def render_cell(self, x: int, y: int) -> str:
+        vertices = self._tri_vertices(x, y)
+        points = ' '.join(f'{vx},{vy}' for vx, vy in vertices)
+        return f'<polygon points="{points}" fill="{self.fill_color}" stroke="{self.stroke_color}" stroke-width="{self.stroke_width}"/>'
+
+
+class KiteRenderer(PolyformRenderer):
+    """Renderer for polykites (kite-shaped tiles)."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.kite_size = 20
+
+    def _kite_to_pixel(self, x: int, y: int) -> Tuple[float, float]:
+        """Convert kite coordinates to pixel center."""
+        px = self.kite_size * 1.5 * x
+        py = self.kite_size * math.sqrt(3) * (y + x * 0.5)
+        return (px, py)
+
+    def _kite_vertices(self, x: int, y: int) -> List[Tuple[float, float]]:
+        """Get vertices of kite at (x, y)."""
+        cx, cy = self._kite_to_pixel(x, y)
+        # Kite shape - simplified
+        s = self.kite_size * 0.8
+        direction = (x % 6) * math.pi / 3
+
+        # Kite vertices
+        d_cos = math.cos(direction)
+        d_sin = math.sin(direction)
+
+        return [
+            (cx + s * d_cos, cy + s * d_sin),
+            (cx + s * 0.5 * math.cos(direction + math.pi/3), cy + s * 0.5 * math.sin(direction + math.pi/3)),
+            (cx - s * 0.3 * d_cos, cy - s * 0.3 * d_sin),
+            (cx + s * 0.5 * math.cos(direction - math.pi/3), cy + s * 0.5 * math.sin(direction - math.pi/3)),
+        ]
+
+    def get_bounds(self) -> Tuple[float, float, float, float]:
+        if not self.coords:
+            return (0, 0, 100, 100)
+        all_vertices = []
+        for x, y in self.coords:
+            all_vertices.extend(self._kite_vertices(x, y))
+        xs = [v[0] for v in all_vertices]
+        ys = [v[1] for v in all_vertices]
+        return (min(xs), min(ys), max(xs), max(ys))
+
+    def render_cell(self, x: int, y: int) -> str:
+        vertices = self._kite_vertices(x, y)
+        points = ' '.join(f'{vx},{vy}' for vx, vy in vertices)
+        return f'<polygon points="{points}" fill="{self.fill_color}" stroke="{self.stroke_color}" stroke-width="{self.stroke_width}"/>'
+
+
+# Fallback renderer for unsupported grid types - uses square representation
+class GenericRenderer(OminoRenderer):
+    """Generic fallback renderer using squares."""
+    pass
+
+
+def get_renderer(grid_type: str, coords: List[Tuple[int, int]]) -> PolyformRenderer:
+    """Factory function to get appropriate renderer for grid type."""
+    renderers = {
+        'O': OminoRenderer,
+        'H': HexRenderer,
+        'I': IamondRenderer,
+        'A': AboloRenderer,
+        'K': KiteRenderer,
+    }
+    renderer_class = renderers.get(grid_type, GenericRenderer)
+    return renderer_class(grid_type, coords)
+
+
+def render_polyform(grid_type: str, coords: List[Tuple[int, int]]) -> str:
+    """Render a polyform to SVG string."""
+    renderer = get_renderer(grid_type, coords)
+    return renderer.render()

--- a/renderings/website/app.js
+++ b/renderings/website/app.js
@@ -1,0 +1,399 @@
+/**
+ * Heesch Polyform Explorer
+ *
+ * JavaScript application for viewing polyform renderings via Modal endpoints.
+ */
+
+// Configuration - Update these URLs after deploying to Modal
+const CONFIG = {
+    // Base URL for Modal endpoints - update after deployment
+    baseUrl: 'https://YOUR_MODAL_USERNAME--heesch-renderings',
+
+    // Endpoint paths
+    endpoints: {
+        render: '/render',
+        renderSync: '/render_sync',
+        list: '/list_polyforms',
+        gridTypes: '/grid_types'
+    },
+
+    // Polling settings for async rendering
+    pollInterval: 1000,  // ms
+    maxPollAttempts: 30
+};
+
+// Sample polyforms for quick testing
+const SAMPLE_POLYFORMS = [
+    { name: 'Polyhex L', gridType: 'H', coords: '0,0_1,0_2,0_2,1' },
+    { name: 'Polyhex Bar', gridType: 'H', coords: '-2,2_-1,1_0,0_1,0_2,0_2,1' },
+    { name: 'Polyomino T', gridType: 'O', coords: '0,0_1,0_2,0_1,1' },
+    { name: 'Polyomino L', gridType: 'O', coords: '0,0_0,1_0,2_1,2' },
+    { name: 'Polyomino Square', gridType: 'O', coords: '0,0_0,1_1,0_1,1' },
+    { name: 'Polyiamond Triangle', gridType: 'I', coords: '0,0_1,0_3,0' },
+    { name: 'Polykite Trio', gridType: 'K', coords: '0,0_1,0_2,0' },
+];
+
+// Grid type info cache
+let gridTypesCache = null;
+
+/**
+ * Initialize the application
+ */
+async function init() {
+    console.log('Initializing Heesch Polyform Explorer...');
+
+    // Set up event listeners
+    document.getElementById('render-btn').addEventListener('click', handleRenderClick);
+    document.getElementById('refresh-list-btn').addEventListener('click', loadPolyformList);
+    document.getElementById('coords-input').addEventListener('keypress', (e) => {
+        if (e.key === 'Enter') handleRenderClick();
+    });
+
+    // Load grid types
+    await loadGridTypes();
+
+    // Load available polyforms
+    await loadPolyformList();
+
+    // Populate sample polyforms
+    populateSamples();
+}
+
+/**
+ * Load grid types from API
+ */
+async function loadGridTypes() {
+    const select = document.getElementById('grid-type');
+
+    try {
+        const response = await fetch(`${CONFIG.baseUrl}${CONFIG.endpoints.gridTypes}`);
+
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+        }
+
+        const data = await response.json();
+        gridTypesCache = data.grid_types;
+
+        select.innerHTML = '';
+        for (const gt of data.grid_types) {
+            const option = document.createElement('option');
+            option.value = gt.abbrev;
+            option.textContent = `${gt.abbrev} - ${gt.full_name}`;
+            select.appendChild(option);
+        }
+    } catch (error) {
+        console.warn('Failed to load grid types from API, using defaults:', error);
+
+        // Fallback to hardcoded grid types
+        const defaultTypes = [
+            { abbrev: 'O', name: 'Polyomino' },
+            { abbrev: 'H', name: 'Polyhex' },
+            { abbrev: 'I', name: 'Polyiamond' },
+            { abbrev: 'o', name: 'Poly-[4.8.8]' },
+            { abbrev: 'T', name: 'Poly-[3.6.3.6]' },
+            { abbrev: 'A', name: 'Polyabolo' },
+            { abbrev: 'D', name: 'Polydrafter' },
+            { abbrev: 'K', name: 'Polykite' },
+            { abbrev: 'h', name: 'Polyhalfcairo' },
+            { abbrev: 'B', name: 'Polybevelhex' },
+        ];
+
+        select.innerHTML = '';
+        for (const gt of defaultTypes) {
+            const option = document.createElement('option');
+            option.value = gt.abbrev;
+            option.textContent = `${gt.abbrev} - ${gt.name}`;
+            select.appendChild(option);
+        }
+    }
+}
+
+/**
+ * Load list of available polyforms
+ */
+async function loadPolyformList() {
+    const listContainer = document.getElementById('polyform-list');
+    listContainer.innerHTML = '<p class="placeholder">Loading...</p>';
+
+    try {
+        const gridType = document.getElementById('grid-type').value;
+        const url = gridType
+            ? `${CONFIG.baseUrl}${CONFIG.endpoints.list}?grid_type=${gridType}`
+            : `${CONFIG.baseUrl}${CONFIG.endpoints.list}`;
+
+        const response = await fetch(url);
+
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+        }
+
+        const data = await response.json();
+
+        if (data.polyforms && data.polyforms.length > 0) {
+            listContainer.innerHTML = '';
+            for (const pf of data.polyforms) {
+                const item = document.createElement('div');
+                item.className = 'polyform-item';
+                item.innerHTML = `
+                    <span class="grid-type">${pf.grid_type}</span>
+                    <span class="coords">${pf.coords}</span>
+                `;
+                item.addEventListener('click', () => {
+                    document.getElementById('grid-type').value = pf.grid_type;
+                    document.getElementById('coords-input').value = pf.coords;
+                    handleRenderClick();
+                });
+                listContainer.appendChild(item);
+            }
+        } else {
+            listContainer.innerHTML = '<p class="placeholder">No polyforms available yet. Render some to add them!</p>';
+        }
+    } catch (error) {
+        console.warn('Failed to load polyform list:', error);
+        listContainer.innerHTML = '<p class="placeholder">Could not load polyforms. API may be unavailable.</p>';
+    }
+}
+
+/**
+ * Populate sample polyforms
+ */
+function populateSamples() {
+    const container = document.getElementById('samples');
+    container.innerHTML = '';
+
+    for (const sample of SAMPLE_POLYFORMS) {
+        const item = document.createElement('div');
+        item.className = 'sample-item';
+        item.innerHTML = `
+            <div class="sample-name">${sample.name}</div>
+            <div class="sample-coords">${sample.gridType}: ${sample.coords}</div>
+        `;
+        item.addEventListener('click', () => {
+            document.getElementById('grid-type').value = sample.gridType;
+            document.getElementById('coords-input').value = sample.coords;
+            handleRenderClick();
+        });
+        container.appendChild(item);
+    }
+}
+
+/**
+ * Handle render button click
+ */
+async function handleRenderClick() {
+    const gridType = document.getElementById('grid-type').value;
+    const coords = document.getElementById('coords-input').value.trim();
+
+    if (!coords) {
+        showStatus('Please enter coordinates', 'error');
+        return;
+    }
+
+    await renderPolyform(gridType, coords);
+}
+
+/**
+ * Render a polyform
+ */
+async function renderPolyform(gridType, coords) {
+    const outputContainer = document.getElementById('render-output');
+    const statusContainer = document.getElementById('render-status');
+
+    outputContainer.innerHTML = '<div class="loading"></div>';
+    showStatus('Requesting rendering...', 'computing');
+
+    try {
+        // First try the async endpoint
+        const response = await fetch(
+            `${CONFIG.baseUrl}${CONFIG.endpoints.render}?grid_type=${encodeURIComponent(gridType)}&coords=${encodeURIComponent(coords)}`
+        );
+
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+        }
+
+        const data = await response.json();
+
+        if (data.status === 'available') {
+            displayRendering(data);
+        } else if (data.status === 'computing') {
+            showStatus('Computing rendering... This may take a moment.', 'computing');
+            // Poll for result
+            await pollForRendering(gridType, data.coords);
+        } else if (data.status === 'error') {
+            showStatus(data.message, 'error');
+            outputContainer.innerHTML = `<p class="placeholder">${data.message}</p>`;
+        }
+    } catch (error) {
+        console.error('Render error:', error);
+
+        // Fallback: Try to render locally using client-side SVG generation
+        try {
+            const svg = renderLocalSVG(gridType, coords);
+            outputContainer.innerHTML = svg;
+            showStatus('Rendered locally (API unavailable)', 'available');
+        } catch (localError) {
+            showStatus(`Failed to render: ${error.message}`, 'error');
+            outputContainer.innerHTML = '<p class="placeholder">Rendering failed. Please check the API connection.</p>';
+        }
+    }
+}
+
+/**
+ * Poll for async rendering result
+ */
+async function pollForRendering(gridType, coords, attempts = 0) {
+    if (attempts >= CONFIG.maxPollAttempts) {
+        showStatus('Rendering is taking longer than expected. Please try again later.', 'error');
+        return;
+    }
+
+    await new Promise(resolve => setTimeout(resolve, CONFIG.pollInterval));
+
+    try {
+        const response = await fetch(
+            `${CONFIG.baseUrl}${CONFIG.endpoints.render}?grid_type=${encodeURIComponent(gridType)}&coords=${encodeURIComponent(coords)}`
+        );
+
+        const data = await response.json();
+
+        if (data.status === 'available') {
+            displayRendering(data);
+        } else if (data.status === 'computing') {
+            showStatus(`Computing rendering... (attempt ${attempts + 1}/${CONFIG.maxPollAttempts})`, 'computing');
+            await pollForRendering(gridType, coords, attempts + 1);
+        } else {
+            showStatus(data.message || 'Unknown error', 'error');
+        }
+    } catch (error) {
+        showStatus(`Poll failed: ${error.message}`, 'error');
+    }
+}
+
+/**
+ * Display a rendering result
+ */
+function displayRendering(data) {
+    const outputContainer = document.getElementById('render-output');
+    outputContainer.innerHTML = data.svg;
+    showStatus(`Rendered ${data.grid_name} (${data.coords})`, 'available');
+
+    // Refresh the list to show newly computed polyforms
+    loadPolyformList();
+}
+
+/**
+ * Show a status message
+ */
+function showStatus(message, type) {
+    const statusContainer = document.getElementById('render-status');
+    statusContainer.textContent = message;
+    statusContainer.className = `status-message ${type}`;
+}
+
+/**
+ * Client-side SVG rendering fallback
+ * This provides basic rendering when the API is unavailable
+ */
+function renderLocalSVG(gridType, coordsStr) {
+    const coords = coordsStr.split('_').map(pair => {
+        const [x, y] = pair.split(',').map(Number);
+        return { x, y };
+    });
+
+    if (gridType === 'O') {
+        return renderOminoSVG(coords);
+    } else if (gridType === 'H') {
+        return renderHexSVG(coords);
+    } else {
+        // Fallback to square rendering
+        return renderOminoSVG(coords);
+    }
+}
+
+/**
+ * Render polyomino SVG locally
+ */
+function renderOminoSVG(coords) {
+    const cellSize = 30;
+    const padding = 20;
+
+    const xs = coords.map(c => c.x);
+    const ys = coords.map(c => c.y);
+    const minX = Math.min(...xs);
+    const minY = Math.min(...ys);
+    const maxX = Math.max(...xs);
+    const maxY = Math.max(...ys);
+
+    const width = (maxX - minX + 1) * cellSize + 2 * padding;
+    const height = (maxY - minY + 1) * cellSize + 2 * padding;
+
+    let cells = '';
+    for (const {x, y} of coords) {
+        const px = (x - minX) * cellSize + padding;
+        const py = (y - minY) * cellSize + padding;
+        cells += `<rect x="${px}" y="${py}" width="${cellSize}" height="${cellSize}" fill="#FFD700" stroke="#000" stroke-width="2"/>`;
+    }
+
+    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" width="${width}" height="${height}">${cells}</svg>`;
+}
+
+/**
+ * Render polyhex SVG locally
+ */
+function renderHexSVG(coords) {
+    const hexSize = 20;
+    const padding = 40;
+
+    function hexToPixel(x, y) {
+        return {
+            px: hexSize * 1.5 * x,
+            py: hexSize * Math.sqrt(3) * (y + x * 0.5)
+        };
+    }
+
+    function hexVertices(cx, cy) {
+        const vertices = [];
+        for (let i = 0; i < 6; i++) {
+            const angle = Math.PI / 3 * i;
+            vertices.push({
+                x: cx + hexSize * Math.cos(angle),
+                y: cy + hexSize * Math.sin(angle)
+            });
+        }
+        return vertices;
+    }
+
+    // Calculate bounds
+    let allVertices = [];
+    for (const {x, y} of coords) {
+        const {px, py} = hexToPixel(x, y);
+        allVertices = allVertices.concat(hexVertices(px, py));
+    }
+
+    const vxs = allVertices.map(v => v.x);
+    const vys = allVertices.map(v => v.y);
+    const minX = Math.min(...vxs);
+    const minY = Math.min(...vys);
+    const maxX = Math.max(...vxs);
+    const maxY = Math.max(...vys);
+
+    const width = maxX - minX + 2 * padding;
+    const height = maxY - minY + 2 * padding;
+    const offsetX = padding - minX;
+    const offsetY = padding - minY;
+
+    let hexagons = '';
+    for (const {x, y} of coords) {
+        const {px, py} = hexToPixel(x, y);
+        const vertices = hexVertices(px + offsetX, py + offsetY);
+        const points = vertices.map(v => `${v.x},${v.y}`).join(' ');
+        hexagons += `<polygon points="${points}" fill="#FFD700" stroke="#000" stroke-width="2"/>`;
+    }
+
+    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" width="${width}" height="${height}">${hexagons}</svg>`;
+}
+
+// Initialize when DOM is ready
+document.addEventListener('DOMContentLoaded', init);

--- a/renderings/website/index.html
+++ b/renderings/website/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Heesch Polyform Explorer</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>Heesch Polyform Explorer</h1>
+            <p class="subtitle">Explore polyforms and their Heesch numbers</p>
+        </header>
+
+        <div class="controls">
+            <div class="control-group">
+                <label for="grid-type">Grid Type:</label>
+                <select id="grid-type">
+                    <option value="">Loading...</option>
+                </select>
+            </div>
+
+            <div class="control-group">
+                <label for="coords-input">Coordinates:</label>
+                <input type="text" id="coords-input" placeholder="e.g., 0,0_1,0_2,0_2,1">
+                <button id="render-btn">Render</button>
+            </div>
+        </div>
+
+        <div class="main-content">
+            <div class="render-panel">
+                <h2>Rendering</h2>
+                <div id="render-output" class="render-output">
+                    <p class="placeholder">Select a polyform or enter coordinates to render</p>
+                </div>
+                <div id="render-status" class="status-message"></div>
+            </div>
+
+            <div class="list-panel">
+                <h2>Available Polyforms</h2>
+                <div class="list-controls">
+                    <button id="refresh-list-btn">Refresh List</button>
+                </div>
+                <div id="polyform-list" class="polyform-list">
+                    <p class="placeholder">Loading available polyforms...</p>
+                </div>
+            </div>
+        </div>
+
+        <div class="sample-polyforms">
+            <h2>Sample Polyforms</h2>
+            <p>Click to render:</p>
+            <div id="samples" class="samples-grid">
+                <!-- Samples will be populated by JS -->
+            </div>
+        </div>
+    </div>
+
+    <script src="app.js"></script>
+</body>
+</html>

--- a/renderings/website/styles.css
+++ b/renderings/website/styles.css
@@ -1,0 +1,289 @@
+/* Heesch Polyform Explorer Styles */
+
+:root {
+    --primary-color: #2c3e50;
+    --secondary-color: #3498db;
+    --accent-color: #e74c3c;
+    --background-color: #ecf0f1;
+    --card-background: #ffffff;
+    --text-color: #2c3e50;
+    --border-color: #bdc3c7;
+    --success-color: #27ae60;
+    --warning-color: #f39c12;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+    background-color: var(--background-color);
+    color: var(--text-color);
+    line-height: 1.6;
+}
+
+.container {
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+header {
+    text-align: center;
+    margin-bottom: 30px;
+    padding: 20px;
+    background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
+    color: white;
+    border-radius: 10px;
+}
+
+header h1 {
+    font-size: 2.5rem;
+    margin-bottom: 10px;
+}
+
+.subtitle {
+    opacity: 0.9;
+    font-size: 1.1rem;
+}
+
+.controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    margin-bottom: 30px;
+    padding: 20px;
+    background: var(--card-background);
+    border-radius: 10px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}
+
+.control-group {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex: 1;
+    min-width: 300px;
+}
+
+.control-group label {
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+.control-group select,
+.control-group input {
+    flex: 1;
+    padding: 10px 15px;
+    border: 2px solid var(--border-color);
+    border-radius: 5px;
+    font-size: 1rem;
+    transition: border-color 0.3s;
+}
+
+.control-group select:focus,
+.control-group input:focus {
+    outline: none;
+    border-color: var(--secondary-color);
+}
+
+button {
+    padding: 10px 20px;
+    background: var(--secondary-color);
+    color: white;
+    border: none;
+    border-radius: 5px;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background 0.3s, transform 0.1s;
+}
+
+button:hover {
+    background: var(--primary-color);
+}
+
+button:active {
+    transform: scale(0.98);
+}
+
+.main-content {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 20px;
+    margin-bottom: 30px;
+}
+
+@media (max-width: 900px) {
+    .main-content {
+        grid-template-columns: 1fr;
+    }
+}
+
+.render-panel,
+.list-panel {
+    background: var(--card-background);
+    border-radius: 10px;
+    padding: 20px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}
+
+.render-panel h2,
+.list-panel h2,
+.sample-polyforms h2 {
+    margin-bottom: 15px;
+    padding-bottom: 10px;
+    border-bottom: 2px solid var(--border-color);
+    color: var(--primary-color);
+}
+
+.render-output {
+    min-height: 300px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 2px dashed var(--border-color);
+    border-radius: 10px;
+    padding: 20px;
+    background: #fafafa;
+}
+
+.render-output svg {
+    max-width: 100%;
+    max-height: 400px;
+}
+
+.placeholder {
+    color: #999;
+    font-style: italic;
+}
+
+.status-message {
+    margin-top: 15px;
+    padding: 10px;
+    border-radius: 5px;
+    text-align: center;
+}
+
+.status-message.computing {
+    background: #fff3cd;
+    color: #856404;
+}
+
+.status-message.available {
+    background: #d4edda;
+    color: #155724;
+}
+
+.status-message.error {
+    background: #f8d7da;
+    color: #721c24;
+}
+
+.list-controls {
+    margin-bottom: 15px;
+}
+
+.polyform-list {
+    max-height: 400px;
+    overflow-y: auto;
+    border: 1px solid var(--border-color);
+    border-radius: 5px;
+}
+
+.polyform-item {
+    padding: 10px 15px;
+    border-bottom: 1px solid var(--border-color);
+    cursor: pointer;
+    transition: background 0.2s;
+}
+
+.polyform-item:last-child {
+    border-bottom: none;
+}
+
+.polyform-item:hover {
+    background: #f0f0f0;
+}
+
+.polyform-item .grid-type {
+    font-weight: 600;
+    color: var(--secondary-color);
+}
+
+.polyform-item .coords {
+    font-family: monospace;
+    font-size: 0.9rem;
+    color: #666;
+}
+
+.sample-polyforms {
+    background: var(--card-background);
+    border-radius: 10px;
+    padding: 20px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}
+
+.samples-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 15px;
+    margin-top: 15px;
+}
+
+.sample-item {
+    padding: 15px;
+    background: #f8f9fa;
+    border: 2px solid var(--border-color);
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.sample-item:hover {
+    border-color: var(--secondary-color);
+    box-shadow: 0 2px 8px rgba(52, 152, 219, 0.3);
+}
+
+.sample-item .sample-name {
+    font-weight: 600;
+    margin-bottom: 5px;
+}
+
+.sample-item .sample-coords {
+    font-family: monospace;
+    font-size: 0.85rem;
+    color: #666;
+    word-break: break-all;
+}
+
+.loading {
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    border: 3px solid #f3f3f3;
+    border-top: 3px solid var(--secondary-color);
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+/* Empty state */
+.empty-state {
+    text-align: center;
+    padding: 40px 20px;
+    color: #999;
+}
+
+.empty-state svg {
+    width: 64px;
+    height: 64px;
+    margin-bottom: 15px;
+    opacity: 0.5;
+}


### PR DESCRIPTION
- Create Modal app with endpoints:
  - /render: Get or compute polyform SVG (async with background computation)
  - /render_sync: Synchronous rendering endpoint
  - /list_polyforms: List available polyforms by grid type
  - /grid_types: List all supported grid types

- Add Python SVG rendering for polyforms:
  - Support for polyominoes, polyhexes, polyiamonds, polyabolos, polykites
  - Fallback generic renderer for other grid types

- Create website frontend:
  - Grid type selector and coordinate input
  - Sample polyforms for quick testing
  - Local fallback rendering when API unavailable
  - Polling for async rendering results

- Volume storage for caching computed renderings