### PR TITLE
Move data loading to build time and add manual compute workflow

### DIFF
--- a/.github/workflows/compute-polyform.yml
+++ b/.github/workflows/compute-polyform.yml
@@ -1,0 +1,79 @@
+name: Compute Polyform
+
+on:
+  workflow_dispatch:
+    inputs:
+      grid_type:
+        description: 'Grid type (hex, iamond, omino, octasquare, trihex, abolo, drafter, kite, halfcairo, bevelhex)'
+        required: true
+        type: choice
+        options:
+          - hex
+          - iamond
+          - omino
+          - octasquare
+          - trihex
+          - abolo
+          - drafter
+          - kite
+          - halfcairo
+          - bevelhex
+      coords:
+        description: 'Coordinates in format: 0,0_1,0_0,1 (underscore separated x,y pairs)'
+        required: true
+        type: string
+      force:
+        description: 'Force recompute even if already exists'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  compute:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compute polyform via Modal API
+        id: compute
+        run: |
+          echo "Computing polyform..."
+          echo "Grid type: ${{ inputs.grid_type }}"
+          echo "Coordinates: ${{ inputs.coords }}"
+          echo "Force: ${{ inputs.force }}"
+
+          # Build the API URL
+          API_URL="https://hloper--heesch-renderings-web.modal.run/compute"
+          PARAMS="grid_type=${{ inputs.grid_type }}&coords=${{ inputs.coords }}"
+          if [ "${{ inputs.force }}" = "true" ]; then
+            PARAMS="${PARAMS}&force=true"
+          fi
+
+          echo "Calling: ${API_URL}?${PARAMS}"
+
+          # Make the API call
+          RESPONSE=$(curl -s -w "\n%{http_code}" "${API_URL}?${PARAMS}")
+          HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+          BODY=$(echo "$RESPONSE" | sed '$d')
+
+          echo "HTTP Status: ${HTTP_CODE}"
+          echo "Response:"
+          echo "$BODY" | jq . || echo "$BODY"
+
+          # Check for success
+          STATUS=$(echo "$BODY" | jq -r '.status // "unknown"')
+          echo "status=${STATUS}" >> $GITHUB_OUTPUT
+
+          if [ "$STATUS" = "error" ]; then
+            MESSAGE=$(echo "$BODY" | jq -r '.message // "Unknown error"')
+            echo "::error::Computation failed: ${MESSAGE}"
+            exit 1
+          fi
+
+          echo "::notice::Computation status: ${STATUS}"
+
+      - name: Summary
+        run: |
+          echo "## Polyform Computation Result" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Grid Type:** ${{ inputs.grid_type }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Coordinates:** ${{ inputs.coords }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Status:** ${{ steps.compute.outputs.status }}" >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .*
 !/.gitignore
+!/.github
 __pycache__/
 *.pyc
 src/sat

--- a/website/scripts/build-data.js
+++ b/website/scripts/build-data.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * Build script to concatenate all JSON witness files into a single JSONL file
- * for the website to consume.
+ * Build script to fetch all witness data from Modal API and create a static JSONL file
+ * for the website to consume at runtime.
  */
 
 import fs from 'fs';
@@ -9,33 +9,73 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const renderingsDir = path.join(__dirname, '../../renderings');
 const outputDir = path.join(__dirname, '../public/data');
 const outputFile = path.join(outputDir, 'witnesses.jsonl');
 
-// Ensure output directory exists
-if (!fs.existsSync(outputDir)) {
-  fs.mkdirSync(outputDir, { recursive: true });
+const MODAL_API_URL = 'https://hloper--heesch-renderings-web.modal.run/list_full';
+
+async function fetchFromModal() {
+  console.log(`Fetching data from Modal API: ${MODAL_API_URL}`);
+
+  const response = await fetch(MODAL_API_URL);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch from Modal: ${response.status} ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  return data.polyforms || [];
 }
 
-// Get all JSON files from renderings directory
-const jsonFiles = fs.readdirSync(renderingsDir)
-  .filter(f => f.endsWith('.json'))
-  .sort();
+async function main() {
+  // Ensure output directory exists
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
 
-console.log(`Found ${jsonFiles.length} JSON files in ${renderingsDir}`);
+  try {
+    const polyforms = await fetchFromModal();
+    console.log(`Received ${polyforms.length} polyforms from Modal API`);
 
-// Write JSONL file
-const outputStream = fs.createWriteStream(outputFile);
+    // Write JSONL file
+    const outputStream = fs.createWriteStream(outputFile);
 
-for (const file of jsonFiles) {
-  const filePath = path.join(renderingsDir, file);
-  const content = fs.readFileSync(filePath, 'utf-8');
-  // Parse and re-stringify to ensure single line
-  const data = JSON.parse(content);
-  outputStream.write(JSON.stringify(data) + '\n');
-  console.log(`  Added: ${file}`);
+    for (const polyform of polyforms) {
+      outputStream.write(JSON.stringify(polyform) + '\n');
+    }
+
+    outputStream.end();
+    console.log(`\nWritten to ${outputFile}`);
+  } catch (error) {
+    console.error('Error fetching from Modal:', error.message);
+
+    // Fallback: try to read from local renderings directory
+    const renderingsDir = path.join(__dirname, '../../renderings');
+    if (fs.existsSync(renderingsDir)) {
+      console.log('Falling back to local renderings directory...');
+
+      const jsonFiles = fs.readdirSync(renderingsDir)
+        .filter(f => f.endsWith('.json'))
+        .sort();
+
+      console.log(`Found ${jsonFiles.length} JSON files in ${renderingsDir}`);
+
+      const outputStream = fs.createWriteStream(outputFile);
+
+      for (const file of jsonFiles) {
+        const filePath = path.join(renderingsDir, file);
+        const content = fs.readFileSync(filePath, 'utf-8');
+        const data = JSON.parse(content);
+        outputStream.write(JSON.stringify(data) + '\n');
+        console.log(`  Added: ${file}`);
+      }
+
+      outputStream.end();
+      console.log(`\nWritten to ${outputFile}`);
+    } else {
+      console.error('No local renderings directory found. Build failed.');
+      process.exit(1);
+    }
+  }
 }
 
-outputStream.end();
-console.log(`\nWritten to ${outputFile}`);
+main();

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -10,13 +10,20 @@ function App() {
   const [error, setError] = useState(null)
 
   useEffect(() => {
-    fetch('https://hloper--heesch-renderings-web.modal.run/list_full')
+    // Load from static JSONL file built at build time
+    fetch('/data/witnesses.jsonl')
       .then(res => {
         if (!res.ok) throw new Error('Failed to load witnesses')
-        return res.json()
+        return res.text()
       })
-      .then(data => {
-        setWitnesses(data.polyforms || [])
+      .then(text => {
+        // Parse JSONL format (one JSON object per line)
+        const polyforms = text
+          .trim()
+          .split('\n')
+          .filter(line => line.length > 0)
+          .map(line => JSON.parse(line))
+        setWitnesses(polyforms)
         setLoading(false)
       })
       .catch(err => {


### PR DESCRIPTION
- Update build-data.js to fetch from Modal API at build time with fallback to local files
- Update App.jsx to load from static JSONL file instead of fetching from Modal at runtime
- Add GitHub Action workflow for manually triggering compute endpoint with grid type and coords
- Update .gitignore to allow .github directory