### PR TITLE
Fix gen command in search_heesch and add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# Claude Code Notes for heesch-sat
+
+## Modal Deployment via gRPC Proxy Tunneling
+
+This environment requires special handling for Modal CLI to work through the HTTP proxy.
+
+### The Problem
+Modal CLI uses gRPC which doesn't natively support HTTP CONNECT proxies. The standard `https_proxy` environment variable is ignored by gRPC-python.
+
+### The Solution
+A Python patch file is used to intercept `asyncio` event loop connections and tunnel them through the HTTP CONNECT proxy:
+
+1. **Patch file location**: `/usr/local/lib/python3.11/dist-packages/grpc_proxy_patch.py`
+2. **Auto-load via sitecustomize**: `/etc/python3.11/sitecustomize.py`
+
+The patch:
+- Intercepts `BaseEventLoop.create_connection()` calls
+- Creates a socket through the HTTP CONNECT proxy
+- Passes the pre-connected socket to the original function
+- Uses the system CA bundle (`/etc/ssl/certs/ca-certificates.crt`) for SSL
+
+### Environment Variables
+- `GRPC_PROXY_DEBUG=1` - Enable debug logging for the proxy patch
+- `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` - Modal credentials
+
+### Deploying Modal
+```bash
+cd /home/user/heesch-sat/modal
+PYTHONPATH=/usr/local/lib/python3.11/dist-packages \
+  MODAL_TOKEN_ID="ak-..." \
+  MODAL_TOKEN_SECRET="as-..." \
+  modal deploy app.py
+```
+
+Note: Must run from the `modal/` directory so relative paths in `add_local_dir("../src", ...)` resolve correctly.
+
+### Modal Endpoint
+- URL: `https://hloper--heesch-renderings-web.modal.run/`
+- Workspace: `hloper`
+
+### Key Endpoints
+- `/search_heesch?grid_type=hex&num_cells=6` - Search for polyforms with Heesch >= 1
+- `/compute?grid_type=hex&coords=0,0_1,0_0,1` - Compute Heesch for a specific polyform
+- `/grid_types` - List supported grid types

--- a/modal/app.py
+++ b/modal/app.py
@@ -355,12 +355,12 @@ def run_render_witness(grid_type: str, coords: List[Tuple[int, int]]) -> dict:
             return json.load(f)
 
 
-def run_gen(grid_abbrev: str, num_cells: int, free: bool = True) -> List[List[Tuple[int, int]]]:
+def run_gen(grid_type: str, num_cells: int, free: bool = True) -> List[List[Tuple[int, int]]]:
     """
     Run the gen binary to generate all polyforms of a given size.
 
     Parameters:
-    - grid_abbrev: Single-character grid type abbreviation (O, H, I, etc.)
+    - grid_type: Full grid type name (hex, iamond, omino, etc.)
     - num_cells: Number of cells in each polyform
     - free: If True, generate free polyforms (topologically unique)
 
@@ -368,7 +368,8 @@ def run_gen(grid_abbrev: str, num_cells: int, free: bool = True) -> List[List[Tu
     """
     import time
 
-    cmd = ["gen", f"-{grid_abbrev}", "-size", str(num_cells)]
+    # gen expects the full grid name like -hex, -iamond, not abbreviations
+    cmd = ["gen", f"-{grid_type}", "-size", str(num_cells)]
     if free:
         cmd.append("-free")
 
@@ -443,16 +444,15 @@ def search_for_heesch(grid_type: str, num_cells: int, max_to_store: int = 3) -> 
     import time
     import heapq
 
-    # Get the grid abbreviation
-    grid_abbrev = GRID_ABBREVS.get(grid_type)
-    if not grid_abbrev:
+    # Validate grid type
+    if grid_type not in GRID_ABBREVS:
         raise ValueError(f"Unknown grid type: {grid_type}")
 
     print(f"Starting Heesch search for {num_cells}-cell {grid_type} polyforms...")
     start_time = time.time()
 
     # Generate all polyforms
-    polyforms = run_gen(grid_abbrev, num_cells, free=True)
+    polyforms = run_gen(grid_type, num_cells, free=True)
 
     if not polyforms:
         return {


### PR DESCRIPTION
- Fix run_gen() to use full grid type names (hex, iamond) instead of abbreviations (H, I) since the gen binary expects -hex not -H
- Add CLAUDE.md documenting the gRPC proxy tunneling setup needed for Modal CLI to work through HTTP CONNECT proxies