### PR TITLE
Fix GitHub Actions Modal authentication

### DIFF
--- a/.github/workflows/compute-polyform.yml
+++ b/.github/workflows/compute-polyform.yml
@@ -51,11 +51,13 @@ jobs:
       - name: Install Modal
         run: pip install modal
 
+      - name: Authenticate with Modal
+        env:
+          MODAL_COMMAND: ${{ secrets.MODAL_COMMAND }}
+        run: eval "$MODAL_COMMAND"
+
       - name: Compute polyform via Modal function
         id: compute
-        env:
-          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
-          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         run: |
           echo "Computing polyform..."
           echo "Grid type: ${{ inputs.grid_type }}"

--- a/.github/workflows/search-heesch.yml
+++ b/.github/workflows/search-heesch.yml
@@ -56,11 +56,13 @@ jobs:
       - name: Install Modal
         run: pip install modal
 
+      - name: Authenticate with Modal
+        env:
+          MODAL_COMMAND: ${{ secrets.MODAL_COMMAND }}
+        run: eval "$MODAL_COMMAND"
+
       - name: Launch Heesch search job on Modal
         id: search
-        env:
-          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
-          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         run: |
           echo "Launching Heesch search job on Modal..."
           echo "Grid type: ${{ inputs.grid_type }}"


### PR DESCRIPTION
Use MODAL_COMMAND secret instead of MODAL_TOKEN_ID/MODAL_TOKEN_SECRET for authenticating with Modal in the workflows.