### PR TITLE
Fix YAML parsing error in compute-polyform workflow

### DIFF
--- a/.github/workflows/compute-polyform.yml
+++ b/.github/workflows/compute-polyform.yml
@@ -80,17 +80,7 @@ jobs:
             if [[ "$input" == "["* ]] && [[ "$input" == *"["*"]"* ]]; then
               # Parse JSON array and convert to underscore format
               # [[0,0], [1,0]] -> "0,0_1,0"
-              local result=$(echo "$input" | python3 -c "
-import sys, json
-try:
-    data = json.loads(sys.stdin.read())
-    if isinstance(data, list):
-        coords = ['%d,%d' % (c[0], c[1]) for c in data]
-        print('_'.join(coords))
-except Exception as e:
-    print('Error: ' + str(e), file=sys.stderr)
-    sys.exit(1)
-")
+              local result=$(echo "$input" | python3 -c "import sys, json; data = json.loads(sys.stdin.read()); print('_'.join(['%d,%d' % (c[0], c[1]) for c in data]))")
               if [ $? -ne 0 ]; then
                 echo "Error: invalid JSON format" >&2
                 return 1


### PR DESCRIPTION
The multi-line Python code for JSON coordinate parsing started at column 0, which broke YAML block scalar indentation rules. Converted to a single-line Python command to maintain proper YAML formatting.